### PR TITLE
Add Cornell Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # obsidian-templates-snippets
 Obsidian templates, snippets, plugins and other third-party tooling that I use to improve. (Plan is to keep it simple so overhead is minimal - no extension rabbithole)
+
+## cornell-notes
+Enables [Cornell Notes](https://en.wikipedia.org/wiki/Cornell_Notes) via CSS snippets.
+
+1. Snippet: https://raw.githubusercontent.com/nopshar/Cornell/main/Cornell.css
+2. Template: https://gist.github.com/skrymets/0de27b2f577208cf254f4e69042b13ce
+
+Note: Original author of the snippet is [skrymets](https://gist.github.com/skrymets), but [nopshar](https://gist.github.com/nopshar) fixed some rendering issues and that is why snippet is referring to [nopshar](https://gist.github.com/nopshar)'s fork.

--- a/snippets/cornell-note/raw.githubusercontent.com_nopshar_Cornell_main_Cornell.css
+++ b/snippets/cornell-note/raw.githubusercontent.com_nopshar_Cornell_main_Cornell.css
@@ -1,0 +1,73 @@
+/** Place this file in your $VAULT_NAME/.obsidian/snippets/ and enable the snippet in the Appearance Settings **/
+
+
+:root {
+    --cue-width: 120px;
+    --cue-offset: var(--cue-width);
+    --cue-line: 1px solid lightgrey;
+}
+
+.markdown-preview-view.cornell-note .markdown-preview-sizer,
+.markdown-source-view.cornell-note .markdown-preview-sizer {
+    max-width: var(--file-line-width);
+    margin-left: auto;
+    margin-right: auto;
+    margin-inline: 110px;
+    width: 100%;
+}
+
+.markdown-preview-view.cornell-note .markdown-preview-sizer > div ,
+.markdown-source-view.cornell-note .markdown-preview-sizer > div {
+    max-width: var(--max-width);
+    width: var(--line-width);
+    margin-inline: var(--content-margin)!important;
+}
+
+.markdown-preview-view.cornell-note .markdown-preview-sizer > div:has(p, ul, ol, pre),
+.markdown-source-view.cornell-note .markdown-preview-sizer > div:has(p, ul, ol, pre)  {
+    border-left: var(--cue-line);
+    padding-left: 20px;
+}
+
+.markdown-preview-view.cornell-note aside:first-line, 
+.markdown-source-view.cornell-note aside:first-line {
+    font-weight: 700;
+}
+
+.markdown-preview-view.cornell-note aside, 
+.markdown-source-view.cornell-note aside {
+    font-style: italic;
+    font-family: var(--font-text);
+    font-size: var(--font-adaptive-normal);
+    font-weight: var(--normal-weight);
+    line-height: var(--line-height);
+    padding: 0px 8px 0px 0px;
+    margin-right: 10px;
+    position: absolute;
+    left: 15px;
+    max-width: var(--cue-width);
+} 
+
+.markdown-preview-view.cornell-note div.cues-header, 
+.markdown-source-view.cornell-note div.cues-header {
+    /* Keep sync with "h1, .markdown-rendered h1" selector */
+    position: absolute;
+    max-width: var(--cue-width);
+    width: var(--cue-width);
+    left: 15px;
+    top: 20;
+    padding: 0px 8px 0px 0px;
+    letter-spacing: -0.015em;
+    line-height: var(--h1-line-height);
+    color: var(--h1-color);
+    font-family: var(--h1-font);
+    font-size: var(--h1-size);
+    font-style: var(--h1-style);
+    font-variant: var(--h1-variant);
+    font-weight: var(--h1-weight);
+}
+
+.markdown-preview-view.cornell-note summary, 
+.markdown-source-view.cornell-note summary {
+    display: none;
+}

--- a/templates/cornell-note/cornell-note.md
+++ b/templates/cornell-note/cornell-note.md
@@ -1,0 +1,37 @@
+---
+cssclass: cornell-note
+---
+
+<div class="cues-header">Cues</div>
+
+# Notes
+
+The Cornell Note-taking System is a popular and effective method for organizing and summarizing information during lectures, readings, or any other form of learning.
+
+<aside>Note's Layout</aside>
+
+The Cornell method offers a specific layout for each page of notes. The note is divided into three sections: 
+- **Cue/Question Column (Left)** — is used to write down questions, keywords, or cues related to the content you're recording in the main notes section.
+- **Note-taking Column (Right)** — here you write your main notes during the lecture or reading. This section should contain the most critical information, main ideas, supporting details, and explanations.
+- **Summary Section (Bottom)** — here you write a concise summary of the main points covered in your notes.
+
+<aside>Note-taking Process</aside>
+
+* Start by listening or reading actively, and jot down the main ideas and supporting details in the Note-taking Column.
+* Use abbreviations and bullet points to keep your notes concise and easy to review.
+* In the Cue/Question Column, write down questions or cues that correspond to the material you're noting in the right column. These questions can be used as study prompts later.
+* If you come across concepts or ideas that you don't understand fully, make a note of it and try to clarify them later through research or by asking your instructor.
+
+<aside>Review and Study</aside>
+
+* After the lecture or reading, review your notes as soon as possible to reinforce the information in your memory.
+* Use the Cue/Question Column to cover the right-hand side of your notes and quiz yourself based on the cues or questions you wrote down.
+* Reflect on the material and try to answer the questions from memory. This active recall helps improve retention.
+* Check your answers and understanding in the Note-taking Column and fill in any gaps or correct any mistakes in your summary section.
+
+---
+
+# Summary
+
+<summary>Write a concise summary here</summary>
+The Cornell Note-taking System is effective because it encourages active engagement during the note-taking process and provides a structured way to review and study the material later. It is widely used by students, professionals, and anyone looking to improve their note-taking and learning efficiency.


### PR DESCRIPTION
## cornell-notes
Enables [Cornell Notes](https://en.wikipedia.org/wiki/Cornell_Notes) via CSS snippets.

1. Snippet: https://raw.githubusercontent.com/nopshar/Cornell/main/Cornell.css
2. Template: https://gist.github.com/skrymets/0de27b2f577208cf254f4e69042b13ce

Note: Original author of the snippet is [skrymets](https://gist.github.com/skrymets), but [nopshar](https://gist.github.com/nopshar) fixed some rendering issues and that is why snippet is referring to [nopshar](https://gist.github.com/nopshar)'s fork.